### PR TITLE
[BE] [#3] 이메일 중복 확인 기능

### DIFF
--- a/src/main/java/aico/backend/global/security/SecurityConfig.java
+++ b/src/main/java/aico/backend/global/security/SecurityConfig.java
@@ -37,7 +37,7 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/user/signup", "/api/user/login").permitAll()
+                        .requestMatchers("/api/user/signup", "/api/user/login", "/api/user/duplicate").permitAll()
                         .anyRequest().authenticated())
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS)

--- a/src/main/java/aico/backend/global/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/aico/backend/global/security/filter/JwtAuthenticationFilter.java
@@ -30,7 +30,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-        if(request.getRequestURI().equals("/api/user/login") || request.getRequestURI().equals("/api/user/signup") ) {
+        if(request.getRequestURI().equals("/api/user/login") || request.getRequestURI().equals("/api/user/signup")  || request.getRequestURI().equals("/api/user/duplicate") ) {
             filterChain.doFilter(request, response);
             return;
         }

--- a/src/main/java/aico/backend/user/controller/UserController.java
+++ b/src/main/java/aico/backend/user/controller/UserController.java
@@ -6,10 +6,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,5 +18,11 @@ public class UserController {
     public ResponseEntity<Void> signUp(@Valid @RequestBody SignUpRequest signUpRequest) {
         userService.signUp(signUpRequest);
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @GetMapping("/duplicate")
+    public ResponseEntity<Boolean> duplicateCheck(@RequestParam String email) {
+        Boolean isDuplicated = userService.isDuplicatedEmail(email);
+        return ResponseEntity.status(HttpStatus.OK).body(isDuplicated);
     }
 }

--- a/src/main/java/aico/backend/user/service/UserService.java
+++ b/src/main/java/aico/backend/user/service/UserService.java
@@ -29,4 +29,8 @@ public class UserService {
         User user = User.from(request,encodedPassword);
         userRepository.save(user);
     }
+
+    public boolean isDuplicatedEmail(String email) {
+        return userRepository.existsByEmail(email);
+    }
 }


### PR DESCRIPTION
## 🔎 이슈 번호
#3 

## 🖥 작업 내용
회원가입 페이지에서 이메일 중복 확인 버튼을 위한 기능을 구현하였습니다.
`/api/user/duplicate?email=이메일`

응답값은 바디에 true 혹은 false로 전송됩니다. 

<br/>

## ✅ PR Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)


